### PR TITLE
[FT6X36] Fix the API about the INT pin mode.

### DIFF
--- a/examples/CustomCallbackTouchDrvInterface/CustomCallbackTouchDrvInterface.ino
+++ b/examples/CustomCallbackTouchDrvInterface/CustomCallbackTouchDrvInterface.ino
@@ -216,7 +216,7 @@ bool setupTouchDrv()
     result = touchDrv->begin(i2c_wr_function, hal_callback, FT3267_SLAVE_ADDRESS);
     if (result) {
         TouchDrvFT6X36 *tmp = static_cast<TouchDrvFT6X36 *>(touchDrv);
-        tmp->interruptTrigger();
+        tmp->interruptPolling();
         const char *model = touchDrv->getModelName();
         Serial.print("Successfully initialized "); Serial.print(model);
         Serial.print(",using "); Serial.print(model); Serial.println(" Driver!");

--- a/examples/TouchDrvInterface_Example/TouchDrvInterface_Example.ino
+++ b/examples/TouchDrvInterface_Example/TouchDrvInterface_Example.ino
@@ -126,7 +126,7 @@ bool setupTouchDrv()
     result = touchDrv->begin(Wire, FT3267_SLAVE_ADDRESS, TOUCH_SDA, TOUCH_SCL);
     if (result) {
         TouchDrvFT6X36 *tmp = static_cast<TouchDrvFT6X36 *>(touchDrv);
-        tmp->interruptTrigger();
+        tmp->interruptPolling();
         const char *model = touchDrv->getModelName();
         Serial.print("Successfully initialized "); Serial.print(model);
         Serial.print(",using "); Serial.print(model); Serial.println(" Driver!");

--- a/examples/TouchDrv_FT6232_GetPoint/TouchDrv_FT6232_GetPoint.ino
+++ b/examples/TouchDrv_FT6232_GetPoint/TouchDrv_FT6232_GetPoint.ino
@@ -60,7 +60,7 @@ void setup()
             delay(1000);
         }
     }
-    touch.interruptTrigger();
+    touch.interruptPolling();
 
     Serial.println("Init FT6X36 Sensor success!");
 }

--- a/src/TouchDrvFT6X36.hpp
+++ b/src/TouchDrvFT6X36.hpp
@@ -180,18 +180,16 @@ public:
         return (buffer[0] << 8) | buffer[1];
     }
 
-    // The interrupt is triggered only if a touch is detected during the scan cycle
+    // The interrupt pin is pulled down when a touch is detected until the touch is released
     void interruptPolling(void)
     {
-        //datasheet this bit is 0,Actually, it's wrong
-        comm->writeRegister(FT6X36_REG_INT_STATUS, 1);
+        comm->writeRegister(FT6X36_REG_INT_STATUS, 0x00);
     }
 
-    // Triggers an interrupt whenever a touch is detected
+    // The interrupt pin will continue to output pulse once the touch is detected until released
     void interruptTrigger(void)
     {
-        //datasheet this bit is 1,Actually, it's wrong
-        comm->writeRegister(FT6X36_REG_INT_STATUS, (uint8_t)0);
+        comm->writeRegister(FT6X36_REG_INT_STATUS, 0x01);
     }
 
     uint8_t getPoint(int16_t *x_array, int16_t *y_array, uint8_t size = 1)


### PR DESCRIPTION
The comments say that the datasheet is wrong. I have read the datasheet and tested it. I am sure the datasheet is correct.
I guess that you misunderstand the meaning of the polling mode and trigger mode. You can reference the timing diagram in the datasheet:
<img width="1370" height="432" alt="polling_mode" src="https://github.com/user-attachments/assets/5d07df7b-d67b-4fdb-83cc-09eb91f815a9" />
<img width="1308" height="432" alt="trigger_mode" src="https://github.com/user-attachments/assets/23d5fe1d-3a00-486d-bfcb-3b1bc7823f59" />
