### PR TITLE
Added missing math include to QMI8658 sensor

### DIFF
--- a/src/SensorQMI8658.hpp
+++ b/src/SensorQMI8658.hpp
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "platform/comm/ComplexStaticDeviceWithHal.hpp"
+#include <math.h>
 
 static constexpr uint8_t  QMI8658_L_SLAVE_ADDRESS = (0x6B);
 static constexpr uint8_t  QMI8658_H_SLAVE_ADDRESS = (0x6A);


### PR DESCRIPTION
`NAN`, `round`, etc. are not recognized.

At least this bug is present in the latest release version. I wonder why it's not triggered in your tests. Maybe other sensors require the math included, too.

ESP IDF release/v5.5 branch